### PR TITLE
Safely clean up the shared storage after the message pump is stopped.

### DIFF
--- a/src/NServiceBus.Transport.InMemory/MessagePump.cs
+++ b/src/NServiceBus.Transport.InMemory/MessagePump.cs
@@ -85,8 +85,14 @@
 
         public async Task Stop()
         {
-            this.cancellationTokenSource?.Cancel();
-            if (this.receiveLoopTask != null) await this.receiveLoopTask;
+            try
+            {
+                this.cancellationTokenSource?.Cancel();
+                if (this.receiveLoopTask != null) await this.receiveLoopTask;
+            } finally
+            {
+                SharedStorage.Instance.Clear();
+            }
         }
     }
 }

--- a/src/NServiceBus.Transport.InMemory/SharedStorage.cs
+++ b/src/NServiceBus.Transport.InMemory/SharedStorage.cs
@@ -51,6 +51,11 @@
             var storage = this.endpointStorage.GetOrAdd(endpointName, new EndpointStorage(endpointName));
             storage.Unsubscribe(eventType);
         }
+
+        public void Clear()
+        {
+            this.endpointStorage.Clear();
+        }
     }
 
     internal class EndpointStorage


### PR DESCRIPTION
Closes #3 